### PR TITLE
switch to https requests

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -108,7 +108,7 @@ export default function Home() {
                       // 16:9
                       // pt: '56.25%',
                     }}
-                    image={`http://assets.iotabots.io/${index + 1}.png`}
+                    image={`https://assets.iotabots.io/${index + 1}.png`}
                     alt="IOTABOT"
                   />
                   <CardContent sx={{ flexGrow: 1 }}>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61916767/145475270-f4f6de1d-a321-4869-9b26-8f14461a1b6e.png)
Using http links is creating a warning on the ssl encryption. Switching to https request brings more trust to the website.
Probably IPFS links will be used in the future, so this will be some temporary improvement