### PR TITLE
Add error handling on walletOfOwner call

### DIFF
--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -26,7 +26,6 @@ export default function Profile() {
 
 
   const [bots, setBots] = React.useState<Array<any>>([]);
-
   const [errorRetrievingBots, setErrorRetrievingBots] = React.useState(false)
   const context = useWeb3React<Web3Provider>()
 
@@ -43,7 +42,7 @@ export default function Profile() {
     image: string;
     name: string;
   }
-
+  
 
 
   React.useEffect(() => {
@@ -54,13 +53,10 @@ export default function Profile() {
         /* eslint-disable */
 
         const web3 = new Web3(window.web3.currentProvider);
-
         let contract = new web3.eth.Contract(IOTABOTS_ABI, IOTABOTS_ADR);
 
         /* eslint-enable */
         console.log("contract", contract)
-
-        let data = await contract.methods.walletOfOwner(account).call();
 
         let data 
         try {
@@ -105,9 +101,16 @@ export default function Profile() {
         </Typography>
         <Connnector />
       </Box>
-      <Box sx={{ textAlign: 'center' }} >
-
-        {bots.map((bot, index) => (
+      <Box sx={{ marginBottom:"10px", textAlign: 'center' }} >
+        {errorRetrievingBots ?      
+            <Typography gutterBottom variant="h6" component="h6">
+              {"There was an error retrieving your IotaBots"}
+            </Typography>
+            :  bots.length === 0 ? 
+            <Typography gutterBottom variant="h6" component="h6">
+              {"You don't own any IotaBots yet :("}
+            </Typography> :
+        bots.map((bot, index) => (
           <Grid item key={index} xs={12} sm={12} md={12}>
             <Card
             // sx={{ width: '100%', display: 'flex', flexDirection: 'column' }}
@@ -135,7 +138,7 @@ export default function Profile() {
             </Card>
           </Grid>
         ))}
-      </Box>ƒ
+      </Box>
     </Container>
   );
 }

--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -27,6 +27,7 @@ export default function Profile() {
 
   const [bots, setBots] = React.useState<Array<any>>([]);
 
+  const [errorRetrievingBots, setErrorRetrievingBots] = React.useState(false)
   const context = useWeb3React<Web3Provider>()
 
   const { connector, library, chainId, account, activate, deactivate, active, error } = context
@@ -61,6 +62,15 @@ export default function Profile() {
 
         let data = await contract.methods.walletOfOwner(account).call();
 
+        let data 
+        try {
+          data = await contract.methods.walletOfOwner(account).call();
+        }
+        catch (e) {
+          setErrorRetrievingBots(true)
+          console.log(e)
+          return new Array<Bot> ();
+        }
         console.log("i", init)
 
         const items: Array<Bot> = await Promise.all(data.map(async (i: any) => {


### PR DESCRIPTION
In the previous version there was two different smart contract addresses. One of them failed for me resulting in a crash. 
So I just added some code to check for errors and display a generic error message if there is one.
I could reproduce the error by using this address for the sc: 0xF1960052d7f8Ad70412C2d6F7D23A9327e0665b1.
Also added a string to say if no iotabots were found on the address.