### PR TITLE
refresh page to load bots on wallet account change

### DIFF
--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -53,7 +53,10 @@ export default function Profile() {
         /* eslint-disable */
 
         const web3 = new Web3(window.web3.currentProvider);
-
+        window.ethereum.on('accountsChanged', function()
+        {
+          window.location.reload();
+        })
         let contract = new web3.eth.Contract(IOTABOTS_ABI, IOTABOTS_ADR);
 
         /* eslint-enable */


### PR DESCRIPTION
Refresh the page when the user switches metamask account to load the bots for the new account. Could also refactor to just update the component instead of refreshing the entire page.