### PR TITLE
fix-seo-description

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,6 +1,6 @@
 export const SEO = {
   title: 'IOTABOTS',
-  description: 'My description',
+  description: 'First NFT Profile Picture Project on IOTA. #DeFi #NFT #GameFi #play2earn',
   openGraph: {
     type: 'website',
     url: 'www.iotabots.io',


### PR DESCRIPTION
should fix "My description" default text in head:
![image](https://user-images.githubusercontent.com/61916767/150683370-8e71cee6-e947-47e5-9bbc-deab2c8c8e2d.png)
