### PR TITLE
fix typo in faq

### DIFF
--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -51,7 +51,7 @@ const FAQ: React.FC = () => (
         <ContentBox
           image='http://assets.iotabots.io/compressed/845.png'
           // eslint-disable-next-line max-len
-          text='Download you favourite one and use it as a profile picture.'
+          text='Download your favourite one and use it as a profile picture.'
           headline='What can I do with my IOTABOT?'
         >
           { }


### PR DESCRIPTION
Fixing typo in FAQ = 'What can I do with my IOTABOT?'
This text is replaced:
Download **you** favourite one and use it as a profile picture. ->   Download **your** favourite one and use it as a profile picture.
